### PR TITLE
Fix: user type failing tests

### DIFF
--- a/test/accountlinking-with-session/combination.flows.test.js
+++ b/test/accountlinking-with-session/combination.flows.test.js
@@ -59,6 +59,9 @@ describe(`Multi-recipe account linking flows w/ session: ${printPath(
 
             assert.strictEqual(addPWResp.body.status, "OK");
             assert.strictEqual(addPWResp.body.user.id, createRespBody.user.id);
+            if (addPWResp.body.user.webauthn) {
+                delete addPWResp.body.user.webauthn;
+            }
             assert.deepStrictEqual(addPWResp.body.user, await getUpdatedUserFromDBForRespCompare(createRespBody.user));
         });
 

--- a/test/accountlinking-with-session/emailpasswordapis.test.js
+++ b/test/accountlinking-with-session/emailpasswordapis.test.js
@@ -68,6 +68,11 @@ describe(`emailpassword accountlinkingTests w/ session: ${printPath(
                 assert.strictEqual(body.status, "OK");
 
                 assert.strictEqual(body.user.id, sessionUser.id);
+
+                if (body.user.webauthn) {
+                    delete body.user.webauthn;
+                }
+
                 assert.deepStrictEqual(body.user, await getUpdatedUserFromDBForRespCompare(sessionUser));
             });
 
@@ -90,6 +95,9 @@ describe(`emailpassword accountlinkingTests w/ session: ${printPath(
                 assert.strictEqual(body.status, "OK");
 
                 assert.strictEqual(body.user.id, sessionUser.id);
+                if (body.user.webauthn) {
+                    delete body.user.webauthn;
+                }
                 assert.deepStrictEqual(body.user, await getUpdatedUserFromDBForRespCompare(sessionUser));
             });
 
@@ -295,6 +303,9 @@ describe(`emailpassword accountlinkingTests w/ session: ${printPath(
                 assert.strictEqual(body.status, "OK");
 
                 assert.strictEqual(body.user.id, sessionUser.id);
+                if (body.user.webauthn) {
+                    delete body.user.webauthn;
+                }
                 assert.deepStrictEqual(body.user, await getUpdatedUserFromDBForRespCompare(sessionUser));
             });
 
@@ -546,6 +557,9 @@ describe(`emailpassword accountlinkingTests w/ session: ${printPath(
                     assert.strictEqual(body.status, "OK");
 
                     assert.strictEqual(body.user.id, sessionUser.id);
+                    if (body.user.webauthn) {
+                        delete body.user.webauthn;
+                    }
                     assert.deepStrictEqual(body.user, await getUpdatedUserFromDBForRespCompare(sessionUser));
                 });
 
@@ -565,6 +579,9 @@ describe(`emailpassword accountlinkingTests w/ session: ${printPath(
                     assert.strictEqual(body.status, "OK");
 
                     assert.strictEqual(body.user.id, sessionUser.id);
+                    if (body.user.webauthn) {
+                        delete body.user.webauthn;
+                    }
                     assert.deepStrictEqual(body.user, await getUpdatedUserFromDBForRespCompare(sessionUser));
                 });
 

--- a/test/accountlinking-with-session/passwordlessapis.test.js
+++ b/test/accountlinking-with-session/passwordlessapis.test.js
@@ -69,6 +69,9 @@ describe(`passwordless accountlinkingTests w/ session: ${printPath(
                     assert.strictEqual(body.status, "OK");
 
                     assert.strictEqual(body.user.id, sessionUser.id);
+                    if (body.user.webauthn) {
+                        delete body.user.webauthn;
+                    }
                     assert.deepStrictEqual(body.user, await getUpdatedUserFromDBForRespCompare(sessionUser));
                 });
 
@@ -92,6 +95,9 @@ describe(`passwordless accountlinkingTests w/ session: ${printPath(
                     assert.strictEqual(body.status, "OK");
 
                     assert.strictEqual(body.user.id, sessionUser.id);
+                    if (body.user.webauthn) {
+                        delete body.user.webauthn;
+                    }
                     assert.deepStrictEqual(body.user, await getUpdatedUserFromDBForRespCompare(sessionUser));
                 });
 
@@ -395,6 +401,9 @@ describe(`passwordless accountlinkingTests w/ session: ${printPath(
                     assert.strictEqual(body.status, "OK");
 
                     assert.strictEqual(body.user.id, sessionUser.id);
+                    if (body.user.webauthn) {
+                        delete body.user.webauthn;
+                    }
                     assert.deepStrictEqual(body.user, await getUpdatedUserFromDBForRespCompare(sessionUser));
                 });
 
@@ -419,6 +428,9 @@ describe(`passwordless accountlinkingTests w/ session: ${printPath(
                     assert.strictEqual(body.status, "OK");
 
                     assert.strictEqual(body.user.id, sessionUser.id);
+                    if (body.user.webauthn) {
+                        delete body.user.webauthn;
+                    }
                     assert.deepStrictEqual(body.user, await getUpdatedUserFromDBForRespCompare(sessionUser));
                 });
 

--- a/test/accountlinking-with-session/thirdpartyapis.test.js
+++ b/test/accountlinking-with-session/thirdpartyapis.test.js
@@ -64,6 +64,10 @@ describe(`thirdparty accountlinkingTests w/ session: ${printPath(
                     assert.strictEqual(body.status, "OK");
 
                     assert.strictEqual(body.user.id, sessionUser.id);
+                    if (body.user.webauthn) {
+                        delete body.user.webauthn;
+                    }
+
                     assert.deepStrictEqual(body.user, await getUpdatedUserFromDBForRespCompare(sessionUser));
                 });
 
@@ -82,6 +86,10 @@ describe(`thirdparty accountlinkingTests w/ session: ${printPath(
                     assert.strictEqual(body.status, "OK");
 
                     assert.strictEqual(body.user.id, sessionUser.id);
+                    if (body.user.webauthn) {
+                        delete body.user.webauthn;
+                    }
+
                     assert.deepStrictEqual(body.user, await getUpdatedUserFromDBForRespCompare(sessionUser));
                 });
 
@@ -539,6 +547,11 @@ describe(`thirdparty accountlinkingTests w/ session: ${printPath(
                     assert.strictEqual(body.status, "OK");
 
                     assert.strictEqual(body.user.id, sessionUser.id);
+
+                    if (body.user.webauthn) {
+                        delete body.user.webauthn;
+                    }
+
                     assert.deepStrictEqual(body.user, await getUpdatedUserFromDBForRespCompare(sessionUser));
                 });
 
@@ -558,6 +571,9 @@ describe(`thirdparty accountlinkingTests w/ session: ${printPath(
                     assert.strictEqual(body.status, "OK");
 
                     assert.strictEqual(body.user.id, sessionUser.id);
+                    if (body.user.webauthn) {
+                        delete body.user.webauthn;
+                    }
                     assert.deepStrictEqual(body.user, await getUpdatedUserFromDBForRespCompare(sessionUser));
                 });
 
@@ -790,6 +806,9 @@ describe(`thirdparty accountlinkingTests w/ session: ${printPath(
                     assert.strictEqual(body.status, "OK");
 
                     assert.strictEqual(body.user.id, sessionUser.id);
+                    if (body.user.webauthn) {
+                        delete body.user.webauthn;
+                    }
                     assert.deepStrictEqual(body.user, await getUpdatedUserFromDBForRespCompare(sessionUser));
                 });
 
@@ -809,6 +828,9 @@ describe(`thirdparty accountlinkingTests w/ session: ${printPath(
                     assert.strictEqual(body.status, "OK");
 
                     assert.strictEqual(body.user.id, sessionUser.id);
+                    if (body.user.webauthn) {
+                        delete body.user.webauthn;
+                    }
                     assert.deepStrictEqual(body.user, await getUpdatedUserFromDBForRespCompare(sessionUser));
                 });
 

--- a/test/accountlinking/emailpasswordapis.test.js
+++ b/test/accountlinking/emailpasswordapis.test.js
@@ -672,8 +672,15 @@ describe(`accountlinkingTests: ${printPath("[test/accountlinking/emailpasswordap
             assert.deepStrictEqual(shouldDoAutomaticAccountLinkingCallParams[3][0].recipeId, "emailpassword");
             assert.deepStrictEqual(shouldDoAutomaticAccountLinkingCallParams[3][0].email, "test@example.com");
             const tpUserForComparison = tpUser.user.toJson();
+
+            // Drop the webauthn key from the user object if it exists
+            const userToCompare = shouldDoAutomaticAccountLinkingCallParams[3][1]
+            if (userToCompare.webauthn) {
+                delete userToCompare.webauthn;
+            }
+
             tpUserForComparison.isPrimaryUser = true;
-            assert.deepStrictEqual(shouldDoAutomaticAccountLinkingCallParams[3][1], JSON.parse(JSON.stringify(tpUserForComparison)));
+            assert.deepStrictEqual(userToCompare, JSON.parse(JSON.stringify(tpUserForComparison)));
         });
 
         it("calling signUpPOST succeeds, and links to older account, if email exists in some non email password, non primary user - account linking enabled, and email verification not required", async function () {

--- a/test/accountlinking/passwordlessapis.test.js
+++ b/test/accountlinking/passwordlessapis.test.js
@@ -1047,6 +1047,9 @@ async function getConsumeCodeTestCase({ pwlessUser, otherRecipeUser, accountLink
         const user = consumeCodeResponse.body.user;
         const userFromGetUser = await supertokens.getUser(user.id);
 
+        if (user.webauthn) {
+            delete user.webauthn;
+        }
         assertJSONEquals(user, userFromGetUser.toJson());
         assert.strictEqual(user.isPrimaryUser, expect.isPrimary);
         if (expect.userId === "other") {

--- a/test/accountlinking/thirdpartyapis.test.js
+++ b/test/accountlinking/thirdpartyapis.test.js
@@ -729,6 +729,10 @@ describe(`accountlinkingTests: ${printPath("[test/accountlinking/thirdpartyapis.
             let overrideParams = await getOverrideParams();
             userInCallback = overrideParams.userInCallback;
 
+            if (userInCallback.webauthn) {
+                delete userInCallback.webauthn;
+            }
+
             assert(userInCallback !== undefined);
             assert.deepStrictEqual(pUser.toJson(), userInCallback);
         });


### PR DESCRIPTION
This PR fixes all the failing tests (with backword compatibility) due to change in the `User` type.